### PR TITLE
Allow PDBM to delete webhooks

### DIFF
--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -106,6 +106,7 @@ data "aws_iam_policy_document" "codebuild" {
 
     actions = [
       "codebuild:DeleteProject",
+      "codebuild:DeleteWebhook",
       "codebuild:UpdateProject",
     ]
 

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -108,6 +108,7 @@ data "aws_iam_policy_document" "codebuild" {
       "codebuild:DeleteProject",
       "codebuild:DeleteWebhook",
       "codebuild:UpdateProject",
+      "codebuild:UpdateWebhook",
     ]
 
     resources = [


### PR DESCRIPTION
To delete the webhooks that belong to their PD's codebuild projects. Removed CodeBuild project's webhook will be left dangling otherwise.