### PR TITLE
Allow PDBM to put and delete ssm parameters

### DIFF
--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -195,6 +195,20 @@ data "aws_iam_policy_document" "ssm" {
   }
 
   statement {
+    sid = "AllowToGetParameter"
+
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/tvlk-secret/codebuild/${var.product_domain}/*",
+    ]
+  }
+
+  statement {
     sid = "AllowToDeleteParameter"
 
     effect = "Allow"
@@ -205,6 +219,20 @@ data "aws_iam_policy_document" "ssm" {
 
     resources = [
       "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/tvlk-secret/codebuild/${var.product_domain}/*",
+    ]
+  }
+
+  statement {
+    sid = "AllowToDescribeParameters"
+
+    effect = "Allow"
+
+    actions = [
+      "ssm:DescribeParameters",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -179,6 +179,36 @@ data "aws_iam_policy_document" "codebuild" {
   }
 }
 
+data "aws_iam_policy_document" "ssm" {
+  statement {
+    sid = "AllowToPutParameter"
+
+    effect = "Allow"
+
+    actions = [
+      "ssm:PutParameter",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/tvlk-secret/codebuild/${var.product_domain}/*",
+    ]
+  }
+
+  statement {
+    sid = "AllowToDeleteParameter"
+
+    effect = "Allow"
+
+    actions = [
+      "ssm:DeleteParameter",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/tvlk-secret/codebuild/${var.product_domain}/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "cloudwatch_logs" {
   statement {
     sid = "AllowToDescribeLogGroups"

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -209,6 +209,20 @@ data "aws_iam_policy_document" "ssm" {
   }
 
   statement {
+    sid = "AllowToListKMSKeys"
+
+    effect = "Allow"
+
+    actions = [
+      "kms:ListResourceTags",
+      "kms:ListKeys",
+      "kms:ListAliases",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     sid = "AllowToEncryptParameter"
 
     effect = "Allow"

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -209,6 +209,20 @@ data "aws_iam_policy_document" "ssm" {
   }
 
   statement {
+    sid = "AllowToEncryptParameter"
+
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt",
+    ]
+
+    resources = [
+      "${var.parameter_kms_key_arn}",
+    ]
+  }
+
+  statement {
     sid = "AllowToDeleteParameter"
 
     effect = "Allow"

--- a/modules/product-domain-build-manager/main.tf
+++ b/modules/product-domain-build-manager/main.tf
@@ -35,7 +35,7 @@ resource "aws_iam_role_policy" "pdbm_s3" {
 }
 
 resource "aws_iam_role_policy" "pdbm_ssm" {
-  name   = "AllowToAccessS3"
+  name   = "AllowToAccessSSM"
   role   = "${module.this.role_name}"
   policy = "${data.aws_iam_policy_document.ssm.json}"
 }

--- a/modules/product-domain-build-manager/main.tf
+++ b/modules/product-domain-build-manager/main.tf
@@ -34,6 +34,12 @@ resource "aws_iam_role_policy" "pdbm_s3" {
   policy = "${data.aws_iam_policy_document.s3.json}"
 }
 
+resource "aws_iam_role_policy" "pdbm_ssm" {
+  name   = "AllowToAccessS3"
+  role   = "${module.this.role_name}"
+  policy = "${data.aws_iam_policy_document.ssm.json}"
+}
+
 resource "aws_iam_role_policy" "pdbm_dynamodb" {
   name   = "AllowToAccessDynamoDB"
   role   = "${module.this.role_name}"

--- a/modules/product-domain-build-manager/variables.tf
+++ b/modules/product-domain-build-manager/variables.tf
@@ -9,6 +9,11 @@ variable "mfa_required" {
   default     = "true"
 }
 
+variable "parameter_kms_key_arn" {
+  description = "The ARN of the KMS key that the PDBM can use to encrypt parameters"
+  type        = "string"
+}
+
 variable "trusted_users" {
   description = "List of ARNs of users that are granted to assume the role"
   type        = "list"


### PR DESCRIPTION
The parameters will later be used by CodeBuild projects. `DescribeParameters` is not needed to create parameter via terraform. ~Giving `DescribeParameters` will let people view others secret too, which might not be desirable~.

Update 1: Turns out `DescribeParameters` only gives people access to the list of parameters, not the value, so it might be okay to be given. `GetParameter` is for people to see and confirm their newly created parameter. It's not really necessary, though