### PR TITLE
Add new permissions required by SSM Parameter Store

### DIFF
--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -187,6 +187,7 @@ data "aws_iam_policy_document" "ssm" {
 
     actions = [
       "ssm:PutParameter",
+      "ssm:AddTagsToResource",
     ]
 
     resources = [
@@ -201,6 +202,8 @@ data "aws_iam_policy_document" "ssm" {
 
     actions = [
       "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:ListTagsForResource",
     ]
 
     resources = [
@@ -243,6 +246,8 @@ data "aws_iam_policy_document" "ssm" {
 
     actions = [
       "ssm:DeleteParameter",
+      "ssm:DeleteParameter",
+      "ssm:RemoveTagsFromResource",
     ]
 
     resources = [

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -246,7 +246,7 @@ data "aws_iam_policy_document" "ssm" {
 
     actions = [
       "ssm:DeleteParameter",
-      "ssm:DeleteParameter",
+      "ssm:DeleteParameters",
       "ssm:RemoveTagsFromResource",
     ]
 

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -247,7 +247,6 @@ data "aws_iam_policy_document" "ssm" {
     actions = [
       "ssm:DeleteParameter",
       "ssm:DeleteParameters",
-      "ssm:RemoveTagsFromResource",
     ]
 
     resources = [


### PR DESCRIPTION
when creating ssm parameter, terraform now needs "ssm:AddTagsToResource" permission.
The **new** AWS System Manager Console requires `DeleteParameters` to delete even a single parameter, so it's added too. I've also added the corresponding listTag permission.