### PR TITLE
Reintroduce events trigger

### DIFF
--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -150,6 +150,22 @@ data "aws_iam_policy_document" "codebuild" {
   }
 
   statement {
+    sid = "AllowToManageEventRule"
+
+    effect = "Allow"
+
+    actions = [
+      "events:DescribeRule",
+      "events:DeleteRule",
+      "events:PutRule",
+    ]
+
+    resources = [
+      "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/${var.product_domain}*",
+    ]
+  }
+
+  statement {
     sid = "AllowToGetEventRule"
 
     effect = "Allow"

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -160,6 +160,7 @@ data "aws_iam_policy_document" "codebuild" {
       "events:EnableRule",
       "events:ListTargetsByRule",
       "events:PutRule",
+      "events:PutTargets",
       "events:RemoveTargets",
     ]
 

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -14,6 +14,7 @@ data "aws_iam_policy_document" "codepipeline" {
 
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/service-role/codepipeline.amazonaws.com/ServiceRoleForCodepipeline_${var.product_domain}*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/service-role/codepipeline.amazonaws.com/ServiceRoleForEvents_${var.product_domain}*",
     ]
   }
 

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -158,6 +158,7 @@ data "aws_iam_policy_document" "codebuild" {
       "events:DescribeRule",
       "events:DeleteRule",
       "events:PutRule",
+      "events:ListTargetsByRule",
     ]
 
     resources = [

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -159,6 +159,7 @@ data "aws_iam_policy_document" "codebuild" {
       "events:DeleteRule",
       "events:PutRule",
       "events:ListTargetsByRule",
+      "events:RemoveTargets",
     ]
 
     resources = [

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -157,8 +157,9 @@ data "aws_iam_policy_document" "codebuild" {
     actions = [
       "events:DescribeRule",
       "events:DeleteRule",
-      "events:PutRule",
+      "events:EnableRule",
       "events:ListTargetsByRule",
+      "events:PutRule",
       "events:RemoveTargets",
     ]
 

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -163,25 +163,39 @@ data "aws_iam_policy_document" "codebuild" {
       "events:PutRule",
       "events:PutTargets",
       "events:RemoveTargets",
+      "events:ListRuleNamesByTarget",
     ]
 
     resources = [
       "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/${var.product_domain}*",
     ]
-  }
 
-  statement {
-    sid = "AllowToGetEventRule"
+    condition = {
+      test     = "StringLikeIfExists"
+      variable = "events:TargetArn"
 
-    effect = "Allow"
+      values = [
+        "arn:aws:codepipeline:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.product_domain}*",
+      ]
+    }
 
-    actions = [
-      "events:ListRuleNamesByTarget",
-    ]
+    condition = {
+      test     = "StringEqualsIfExists"
+      variable = "events:source"
 
-    resources = [
-      "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*",
-    ]
+      values = [
+        "aws.s3",
+      ]
+    }
+
+    condition = {
+      test     = "StringEqualsIfExists"
+      variable = "events:detail-type"
+
+      values = [
+        "AWS API Call via CloudTrail",
+      ]
+    }
   }
 
   statement {

--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "codepipeline" {
 
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/service-role/codepipeline.amazonaws.com/ServiceRoleForCodepipeline_${var.product_domain}*",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/service-role/codepipeline.amazonaws.com/ServiceRoleForEvents_${var.product_domain}*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/service-role/events.amazonaws.com/ServiceRoleForEvents_${var.product_domain}*",
     ]
   }
 


### PR DESCRIPTION
As AWS might deprecate the CodePipeline polling feature in the future (according to a support ticket in our build account), I think we should bring back this feature (push pipeline trigger). This is also AWS' recommended way of CodePipeline detection changes.
The PDBM needs an additional permission to create a cloudwatch rule, which will trigger CodePipeline when there's an S3 push action