### PR TITLE
Add a policy for PDBM: invalidate build cache

### DIFF
--- a/modules/product-domain-build-manager/data.tf
+++ b/modules/product-domain-build-manager/data.tf
@@ -109,6 +109,7 @@ data "aws_iam_policy_document" "codebuild" {
       "codebuild:DeleteWebhook",
       "codebuild:UpdateProject",
       "codebuild:UpdateWebhook",
+      "codebuild:InvalidateProjectCache",
     ]
 
     resources = [


### PR DESCRIPTION
Enable PDBMs to invalidate their build projects' cache
Build may fail if the cache is problematic (e.g. wrong / troublesome dependencies was used)

This feature is inspired from @justinusokky's feedback